### PR TITLE
update pkts_num_margin and pkts_num_leak_out for topo-t2

### DIFF
--- a/tests/qos/files/qos.yml
+++ b/tests/qos/files/qos.yml
@@ -3545,7 +3545,7 @@ qos_params:
             cell_size: 384
         topo-t2:
             100000_300m:
-                pkts_num_leak_out: 8
+                pkts_num_leak_out: 0
                 xoff_1:
                     dscp: 3
                     ecn: 1
@@ -3553,7 +3553,7 @@ qos_params:
                     pkts_num_trig_pfc: 10300
                     pkts_num_trig_ingr_drp: 10589
                     packet_size: 1350
-                    pkts_num_margin: 4
+                    pkts_num_margin: 10
                 xoff_2:
                     dscp: 4
                     ecn: 1
@@ -3561,9 +3561,9 @@ qos_params:
                     pkts_num_trig_pfc: 10300
                     pkts_num_trig_ingr_drp: 10589
                     packet_size: 1350
-                    pkts_num_margin: 4
+                    pkts_num_margin: 10
             400000_300m:
-                pkts_num_leak_out: 10
+                pkts_num_leak_out: 0
                 xoff_1:
                     dscp: 3
                     ecn: 1
@@ -3571,7 +3571,7 @@ qos_params:
                     pkts_num_trig_pfc: 9923
                     pkts_num_trig_ingr_drp: 10589
                     packet_size: 1350
-                    pkts_num_margin: 4
+                    pkts_num_margin: 10
                 xoff_2:
                     dscp: 4
                     ecn: 1
@@ -3579,7 +3579,7 @@ qos_params:
                     pkts_num_trig_pfc: 9923
                     pkts_num_trig_ingr_drp: 10589
                     packet_size: 1350
-                    pkts_num_margin: 4
+                    pkts_num_margin: 10
     jr2:
         topo-any:
             100000_300m:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
- set pkts_num_leak_out to 0 since there is code to automatically fill the leakout for the xoff test.
- increase pkts_num_margin to 10 according to script debug result.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
